### PR TITLE
test(RHINENG-19775): Add a test for owner_id access rule on cert-auth requests

### DIFF
--- a/tests/fixtures/mq_fixtures.py
+++ b/tests/fixtures/mq_fixtures.py
@@ -22,6 +22,7 @@ from tests.helpers.api_utils import TAGS
 from tests.helpers.mq_utils import MockEventProducer
 from tests.helpers.mq_utils import MockFuture
 from tests.helpers.mq_utils import wrap_message
+from tests.helpers.test_utils import SYSTEM_IDENTITY
 from tests.helpers.test_utils import base_host
 from tests.helpers.test_utils import generate_uuid
 from tests.helpers.test_utils import get_platform_metadata
@@ -44,9 +45,10 @@ def mq_create_or_update_host(
         consumer_class=IngressMessageConsumer,
         operation_args=None,
         notification_event_producer=notification_event_producer_mock,
+        identity=SYSTEM_IDENTITY,
     ):
         if not platform_metadata:
-            platform_metadata = get_platform_metadata()
+            platform_metadata = get_platform_metadata(identity=identity)
 
         message = wrap_message(host_data.data(), platform_metadata=platform_metadata, operation_args=operation_args)
         consumer = consumer_class(None, flask_app, event_producer_mock, notification_event_producer)

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -14,8 +14,10 @@ from app import process_identity_header
 from app.auth.identity import Identity
 from app.auth.identity import IdentityType
 from app.models import Host
+from app.utils import HostWrapper
 from tests.helpers.api_utils import HOST_URL
 from tests.helpers.api_utils import SYSTEM_PROFILE_URL
+from tests.helpers.api_utils import build_hosts_url
 from tests.helpers.api_utils import build_token_auth_header
 from tests.helpers.test_utils import RHSM_ERRATA_IDENTITY_PROD
 from tests.helpers.test_utils import RHSM_ERRATA_IDENTITY_STAGE
@@ -24,6 +26,8 @@ from tests.helpers.test_utils import SYSTEM_IDENTITY
 from tests.helpers.test_utils import USER_IDENTITY
 from tests.helpers.test_utils import X509_IDENTITY
 from tests.helpers.test_utils import generate_uuid
+from tests.helpers.test_utils import minimal_host
+from tests.helpers.test_utils import valid_system_profile
 
 
 def invalid_identities(identity_type: IdentityType) -> list[dict[str, Any]]:
@@ -373,3 +377,26 @@ def test_access_rhsm_identity_with_org_id_header(
         if response_host["id"] == host_id:
             found = True
     assert found
+
+
+def test_get_hosts_with_system_identity(
+    mq_create_or_update_host: Callable[..., HostWrapper], api_get: Callable[..., tuple[int, dict]]
+):
+    # Test that API grants access only to hosts that have owner_id == identity.system.cn if we use system identity
+    hosts_data = [minimal_host() for _ in range(3)]
+    hosts_data[0].system_profile = valid_system_profile(owner_id=SYSTEM_IDENTITY["system"]["cn"])  # correct owner_id
+    hosts_data[1].system_profile = valid_system_profile(owner_id=generate_uuid())  # incorrect owner_id
+    hosts_data[2].system_profile = valid_system_profile()  # no owner_id
+    hosts_data[2].system_profile.pop("owner_id", None)
+
+    hosts = []
+    for host_data in hosts_data:
+        hosts.append(
+            mq_create_or_update_host(host_data, identity=USER_IDENTITY)  # User can create hosts with any owner_id
+        )
+
+    response_status, response_data = api_get(build_hosts_url(), SYSTEM_IDENTITY)
+
+    assert response_status == 200
+    assert len(response_data["results"]) == 1
+    assert response_data["results"][0]["id"] == hosts[0].id


### PR DESCRIPTION
# Overview

This PR is being created to address [RHINENG-19775](https://issues.redhat.com/browse/RHINENG-19775).

This PR adds a test to help debug an issue where owner_id filter is not applied to API requests with SYSTEM (cert-auth) identity.

## PR Checklist

- [ ] Keep PR title short, ideally under 72 characters
- [ ] Descriptive comments provided in complex code blocks
- [ ] Include raw query examples in the PR description, if adding/modifying SQL query
- [ ] Tests: validate optimal/expected output
- [ ] Tests: validate exceptions and failure scenarios
- [ ] Tests: edge cases
- [ ] Recovers or fails gracefully during potential resource outages (e.g. DB, Kafka)
- [ ] Uses [type hinting](https://docs.python.org/3/library/typing.html), if convenient
- [ ] Documentation, if this PR changes the way other services interact with host inventory
- [ ] Links to related PRs

## Secure Coding Practices Documentation Reference

You can find documentation on this checklist [here](https://github.com/RedHatInsights/secure-coding-checklist).

## Secure Coding Checklist

- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
